### PR TITLE
Changing PostCSS to Peer Dependency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/malchata/node-autorem/issues"
   },
   "peerDependencies": {
-    "postcss": "^8.3.0"
+    "postcss": "^8.4.27"
   },
   "homepage": "https://github.com/malchata/node-autorem#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autorem",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A CSS post-processor that generates rems for pixel values.",
   "main": "lib/autorem.js",
   "scripts": {
@@ -25,8 +25,8 @@
   "bugs": {
     "url": "https://github.com/malchata/node-autorem/issues"
   },
-  "dependencies": {
-    "postcss": "^5.0.0"
+  "peerDependencies": {
+    "postcss": "^8.0.0"
   },
   "homepage": "https://github.com/malchata/node-autorem#readme"
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/malchata/node-autorem/issues"
   },
   "peerDependencies": {
-    "postcss": "^8.0.0"
+    "postcss": "^8.3.0"
   },
   "homepage": "https://github.com/malchata/node-autorem#readme"
 }


### PR DESCRIPTION
Hey there friend! We use this plugin on several sites and we recently starting getting some vulnerability warnings because it depended on PostCSS < 8.2.13. So, I jumped in here and updated PostCSS to a peer dependency and bumped the version. Let me know what you think!